### PR TITLE
Extending LAVA docker file and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN export LANG=en_US.UTF-8
 #RUN echo 'Acquire::http { Proxy "http://dockerproxy:3142"; };' >> /etc/apt/apt.conf.d/01proxy
 
 # Add services helper utilities to start and stop LAVA
-ADD stop.sh .
-ADD start.sh .
+COPY stop.sh .
+COPY start.sh .
 
 ## Install debian packages used by the container
 RUN apt-get update && apt-get install -y \
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Install lava and configure apache to run the lava server
-ADD preseed.txt /data/
+COPY preseed.txt /data/
 RUN apt-get update && \
     service postgresql start && \
     debconf-set-selections < /data/preseed.txt && \
@@ -34,11 +34,11 @@ RUN apt-get update && \
     hostname > /hostname  #log the hostname used during install for the slave name
 
 # Create a admin user (Insecure note, this creates a default user, username: admin/admin)
-ADD createsuperuser.sh /tools/
+COPY createsuperuser.sh /tools/
 RUN /start.sh && /tools/createsuperuser.sh && /stop.sh
 
 # Add devices to the server (ugly, but it works)
-ADD add-kvm-to-lava.sh /tools/
+COPY add-kvm-to-lava.sh /tools/
 RUN /start.sh && /tools/add-kvm-to-lava.sh && \
     /usr/share/lava-server/add_device.py kvm kvm01 && \
     /usr/share/lava-server/add_device.py qemu-aarch64 qemu-aarch64-01 && \
@@ -46,7 +46,7 @@ RUN /start.sh && /tools/add-kvm-to-lava.sh && \
     /stop.sh
 
 # To run jobs using python XMLRPC, we need the API token (really ugly)
-ADD getAPItoken.sh /tools/
+COPY getAPItoken.sh /tools/
 RUN /start.sh && /tools/getAPItoken.sh && /stop.sh
 
 # Add a Pipeline device
@@ -60,12 +60,12 @@ RUN /start.sh && mkdir -p /etc/dispatcher-config/devices && \
     /stop.sh
 
 # Add some job submission utilities
-ADD submit.py /tools/
-ADD submityaml.py /tools/
-ADD submittestjob.sh .
-ADD kvm-basic.json /tools/
-ADD kvm-qemu-aarch64.json /tools/
-ADD qemu.yaml /tools/
+COPY submit.py /tools/
+COPY submityaml.py /tools/
+COPY submittestjob.sh .
+COPY kvm-basic.json /tools/
+COPY kvm-qemu-aarch64.json /tools/
+COPY qemu.yaml /tools/
 
 # Add support for SSH for remote configuration
 RUN mkdir /var/run/sshd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM akbennett/lava:debian-sid
+FROM debian:sid
 
 RUN export LANG=en_US.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,5 +75,4 @@ RUN apt-get update && \
 
 EXPOSE 80
 CMD bash -C '/start.sh' && \
-    '/usr/sbin/sshd' && \
     '/bin/bash'

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
     a2dissite 000-default && \
     a2ensite lava-server && \
     /stop.sh && \
+    rm -rf /var/lib/apt/lists/* && \
     hostname > /hostname  #log the hostname used during install for the slave name
 
 # Create a admin user (Insecure note, this creates a default user, username: admin/admin)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN export LANG=en_US.UTF-8
 #RUN echo 'Acquire::http { Proxy "http://dockerproxy:3142"; };' >> /etc/apt/apt.conf.d/01proxy
 
 ## Install debian packages used by the container
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     postgresql \
     qemu-system \
     expect \
@@ -15,6 +15,11 @@ RUN apt-get update && apt-get install -y \
     android-tools-fastboot \
     cu \
     screen \
+    lava-dispatcher \
+    lava-tool \
+    lava-coordinator \
+    lava-dev \
+    linaro-image-tools \
  && rm -rf /var/lib/apt/lists/*
 
 # Add services helper utilities to start and stop LAVA

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,10 @@ ADD kvm-basic.json /tools/
 ADD kvm-qemu-aarch64.json /tools/
 ADD qemu.yaml /tools/
 
-# Add additional packages for remote configuration
-#  -- Add SSH
-RUN mkdir /var/run/sshd
-RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-RUN echo 'root:password' | chpasswd
+# Add support for SSH for remote configuration
+RUN mkdir /var/run/sshd && \
+    sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    echo 'root:password' | chpasswd
 EXPOSE 22
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,6 @@ RUN /start.sh && mkdir -p /etc/dispatcher-config/devices && \
     /stop.sh
 
 EXPOSE 80
-CMD bash -C '/start.sh' && \
-    '/bin/bash'
+CMD /start.sh && bash
+## Following CMD option starts the lava container without a shell and exposes the logs
+#CMD /start.sh && tail -f /var/log/lava-*/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,20 @@ FROM debian:sid
 
 RUN export LANG=en_US.UTF-8
 
-#start and stop services helper utilities
+# Add services helper utilities to start and stop LAVA
 ADD stop.sh .
 ADD start.sh .
 
-#install lava and configure apache to run the lava server
+# Install lava and configure apache to run the lava server
 ADD preseed.txt /data/
 RUN apt-get update && apt-get install -y postgresql && \
     service postgresql start && \
     debconf-set-selections < /data/preseed.txt && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install lava && \
     a2dissite 000-default && \
-    a2ensite lava-server && \ 
+    a2ensite lava-server && \
     /stop.sh && \
-    hostname > /hostname  #log the hostname used during install for the slave name 
+    hostname > /hostname  #log the hostname used during install for the slave name
 
 # Add qemu-system so we can run jobs on a qemu target
 RUN apt-get update && apt-get -y install qemu-system
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get -y install qemu-system
 # Create a admin user (Insecure note, this creates a default user, username: admin/admin)
 ADD createsuperuser.sh /tools/
 RUN apt-get update && apt-get -y install expect && \
-    /start.sh && /tools/createsuperuser.sh && /stop.sh 
+    /start.sh && /tools/createsuperuser.sh && /stop.sh
 
 # Add devices to the server (ugly, but it works)
 ADD add-kvm-to-lava.sh /tools/
@@ -37,7 +37,7 @@ RUN /start.sh && /tools/add-kvm-to-lava.sh && \
 ADD getAPItoken.sh /tools/
 RUN /start.sh && /tools/getAPItoken.sh && /stop.sh
 
-#Add a Pipeline device
+# Add a Pipeline device
 RUN /start.sh && mkdir -p /etc/dispatcher-config/devices && \
     cp /usr/lib/python2.7/dist-packages/lava_scheduler_app/tests/devices/qemu01.jinja2 \
        /etc/dispatcher-config/devices/ && \
@@ -63,7 +63,7 @@ RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/s
 RUN echo 'root:password' | chpasswd
 EXPOSE 22
 
-# Install basic tools for physically connected LAVA target control 
+# Install basic tools for physically connected LAVA target control
 RUN apt-get update && \
      apt-get -y install vim && \
      apt-get -y install android-tools-fastboot && \
@@ -74,4 +74,3 @@ EXPOSE 80
 CMD bash -C '/start.sh' && \
     '/usr/sbin/sshd' && \
     '/bin/bash'
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,6 @@ RUN /start.sh && /tools/add-kvm-to-lava.sh && \
     echo "root_part=1" >> /etc/lava-dispatcher/devices/kvm01.conf && \
     /stop.sh
 
-# To run jobs using python XMLRPC, we need the API token (really ugly)
-COPY getAPItoken.sh /tools/
-RUN /start.sh && /tools/getAPItoken.sh && /stop.sh
-
 # Add a Pipeline device
 RUN /start.sh && mkdir -p /etc/dispatcher-config/devices && \
     cp /usr/lib/python2.7/dist-packages/lava_scheduler_app/tests/devices/qemu01.jinja2 \
@@ -77,6 +73,10 @@ RUN /start.sh && mkdir -p /etc/dispatcher-config/devices && \
     lava-server manage device-dictionary --hostname qemu01 \
        --import /etc/dispatcher-config/devices/qemu01.jinja2 && \
     /stop.sh
+
+# To run jobs using python XMLRPC, we need the API token (really ugly)
+COPY getAPItoken.sh /tools/
+RUN /start.sh && /tools/getAPItoken.sh && /stop.sh
 
 EXPOSE 80
 CMD /start.sh && bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM debian:sid
 
 RUN export LANG=en_US.UTF-8
 
+# Remove comment to enable local proxy server (e.g. apt-cacher-ng)
+#RUN echo 'Acquire::http { Proxy "http://dockerproxy:3142"; };' >> /etc/apt/apt.conf.d/01proxy
+
 # Add services helper utilities to start and stop LAVA
 ADD stop.sh .
 ADD start.sh .

--- a/README.md
+++ b/README.md
@@ -15,24 +15,56 @@ Where `lavadev` is the Docker image name and can be chosen at the time of build.
 To run the image from a host terminal / command line execute the following:
 
 ```
-sudo docker run -it  -v /boot:/boot  -v /lib/modules:/lib/modules -v $PWD/fileshare:/opt/fileshare -v /dev/bus/usb:/dev/bus/usb --device=/dev/ttyUSB0 -p 8000:80 -p 2022:22  -h de2384825135 --privileged=true lavadev
+sudo docker run -it  -v /boot:/boot -v /lib/modules:/lib/modules -v $PWD/fileshare:/opt/fileshare -v /dev/bus/usb:/dev/bus/usb --device=/dev/ttyUSB0 -p 8000:80 -p 2022:22 -h <HOSTNAME> --privileged=true lavadev
 ```
+Where HOSTNAME is the hostname used during the container build process (check the docker build log), as that is the name used for the lava-slave. You can use de2384825135 as the pre-built container hostname.
 
 In the above command:
 * `-v /boot:/boot` and `-v /lib/modules:/lib/modules` is neccessary due to libguestfs requireing a kernel and modules before it will run
-*  `-v $PWD/fileshare:/opt/fileshare` Includes a shared directory volume between the container and the host OS (./fileshare).  Thus when invoking the docker run command, it should be done from a directory with ./fileshare in it.
+* `-v $PWD/fileshare:/opt/fileshare` Includes a shared directory volume between the container and the host OS (./fileshare).  Thus when invoking the docker run command, it should be done from a directory with ./fileshare in it.
 * `-v /dev/bus/usb:/dev/bus/usb` opens up the USB ports so that fastboot can be connected to a physical target through USB.
 * `--device=/dev/ttyUSB0` assosiates the physical serial USB debug port so that a console can be accessed from the container command line using the pre-installed "screen" utility. Note that `ttyUSB0` can change from host to host.
     ```shell
     screen /dev/ttyUSB0 115200        //  to exit screen type `<ctl-a> <ctl-d>`
     ```
 * `-p 8000:80` Opens up a network port to the host network so that the user can access the LAVA UI from a browser on another computer on the network `<host network IP address>:8000`
-* `-p 2022:22` opens up a ssh port 2022 for access from other hosts on the network to the container.  The host:password is "root" and "password".  Example:  `ssh root@<ip address of LAVA container host> -p 2022`.  This is mapped to 2022 for the use case where the Ubuntu host is already running sshd with the default port of 22 to prevent a conflict.
+* `-p 2022:22` opens up a ssh port 2022 for access from other hosts on the network to the container.  The host:password is "root" and "password".  Example:  `ssh root@<ip address of LAVA container host> -p 2022`.  This is mapped to 2022 for the use case where the host is already running sshd with the default port of 22 to prevent a conflict. SSH is not enabled by default, change Dockerfile and enable if needed (avoid security issues).
 * `-h de2384825135`  -- with v2, LAVA needs to know the name of the worker machine.
-* The final parameter is the image ID that the Container will be run.  In the above example, we use `lavadev` that was defined at build time.  This dockerfile is also built and stored on [docker hub](https://hub.docker.com/r/akbennett/lava-docker) as `akbennett/lava-docker`. 
+* The final parameter is the image ID that the Container will be run.  In the above example, we use `lavadev` that was defined at build time.  This dockerfile is also built and stored on [docker hub](https://hub.docker.com/r/akbennett/lava-docker) as `akbennett/lava-docker`.
 
 ## A quick test
 A script is included in the install to verify that this install was successful. It will kick off several QEMU tests within LAVA.  Once kicked off from the command line, progress of the tests can also be monitored from the LAVA Browser interface.  To execute this command from the container command line, enter `/submittestjob.sh`.  Point your browser to https://localhost:8000/scheduler/alljobs to view the job status.
+
+## Pushing jobs from your local host
+You can also use the submit python helpers to submit test jobs to the running container. To submit jobs from your host machine you first need to extract the LAVA api key that was defined when building the container, then just use the same scripts that are available in this repository.
+
+Extract the LAVA api key:
+
+```
+sudo docker run lavadev cat /apikey.txt
+ss1c4huo3qw9mqnysm367buth09yuqwkohfd3hct0f62dwstmggpdexg1hrrwck5w0g1oxo3nqnx0ny6n38b1uxeo4s8ii6gz1jiles3zhjo1qiyyr0qzqk51prt7sb7
+```
+
+Submit a custom job from your host machine:
+
+```
+echo ss1c4huo3qw9mqnysm367buth09yuqwkohfd3hct0f62dwstmggpdexg1hrrwck5w0g1oxo3nqnx0ny6n38b1uxeo4s8ii6gz1jiles3zhjo1qiyyr0qzqk51prt7sb7 > apikey.txt
+./submit.py -k apikey.txt --port 8000 kvm-qemu-aarch64.json
+./submityaml.py -k apikey.txt --port 8000 -p qemu.yaml
+```
+
+# Running the container as a background service
+Change the container Dockerfile to execute the lava-server and output the log files by default (`CMD /start.sh && tail -f /var/log/lava-*/*`), and detach the running container:
+
+```
+sudo docker run -d -v /boot:/boot -v /lib/modules:/lib/modules -v /tmp/share/:/opt/fileshare -v /dev/bus/usb:/dev/bus/usb --device=/dev/ttyUSB0 -p 8000:80 -p 2022:22 -h de2384825135 --privileged=true lavadev
+```
+
+To access the LAVA service log files just run docker logs:
+
+```
+sudo docker logs -f lavadev
+```
 
 # Alternative Configuration Options
 * Check out the Wiki for additional configuration options https://github.com/akbennett/lava-docker/wiki

--- a/getAPItoken.sh
+++ b/getAPItoken.sh
@@ -25,5 +25,9 @@ curl -b cookies.txt -c cookies.txt -d $createapi -X POST $lavaurl/api/tokens/cre
 #retrieve the api key and store it in a file
 curl -b cookies.txt http://localhost/admin/linaro_django_xmlrpc/authtoken/1/change/ | grep id_secret | sed -n 's/.*value="\([^"]*\).*/\1/p' > apikey.txt 
 
-echo -n "APIKEY="
-cat apikey.txt
+echo -e "\n\n#####################################\n"
+echo -e "# LAVA ADMIN USER = $adminuser"
+echo -e "# LAVA ADMIN PASSWD = $adminpass"
+echo -e "# LAVA SLAVE HOSTNAME = `cat /hostname`"
+echo -n "# LAVA APIKEY = `cat apikey.txt`"
+echo -e "\n\n#####################################\n"

--- a/preseed.txt
+++ b/preseed.txt
@@ -1,1 +1,1 @@
-lava-server   lava-server/instance-name string test-instance
+lava-server   lava-server/instance-name string lava-docker-instance

--- a/submit.py
+++ b/submit.py
@@ -28,6 +28,8 @@ def setup_args_parser():
                    type=lambda x: is_valid_file(parser, x, 'r'))
     parser.add_argument("-d", "--debug", action="store_true", help="Display verbose debug details")
     parser.add_argument("-p", "--poll", action="store_true", help="poll job status until job completes")
+    parser.add_argument("-k", "--apikey", default="apikey.txt", help="File containing the LAVA api key")
+    parser.add_argument("--port", default="80", help="LAVA/Apache default port number")
 
     return parser.parse_args()
 
@@ -91,12 +93,12 @@ def process():
     print "Submitting test job to LAVA server"
     loadConfiguration()
     user = "admin"
-    with open("/apikey.txt") as f: 
+    with open(args.apikey) as f:
         line = f.readline()
         apikey = line.rstrip('\n')
 
-    server_str = 'http://localhost'
-    xmlrpc_str = 'http://' + user + ":" + apikey + "@localhost" + '/RPC2/'
+    server_str = 'http://localhost' + ":" + args.port
+    xmlrpc_str = 'http://' + user + ":" + apikey + "@localhost" + ":" + args.port + '/RPC2/'
     server = xmlrpclib.ServerProxy(xmlrpc_str)
     server.system.listMethods()
 

--- a/submittestjob.sh
+++ b/submittestjob.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 echo "Submit basic kvm job for v1 dispatcher device"
-/tools/submit.py /tools/kvm-basic.json
+/tools/submit.py -k /apikey.txt /tools/kvm-basic.json
 echo "Submit basic qemu-aarch64 job for v1 dispatcher device"
-/tools/submit.py /tools/kvm-qemu-aarch64.json
+/tools/submit.py -k /apikey.txt /tools/kvm-qemu-aarch64.json
 
 #submit a pipeline job
 echo "Submit and wait for v2/pipeline device to complete"
-/tools/submityaml.py -p /tools/qemu.yaml
+/tools/submityaml.py -k /apikey.txt -p /tools/qemu.yaml

--- a/submityaml.py
+++ b/submityaml.py
@@ -27,6 +27,8 @@ def setup_args_parser():
                    type=lambda x: is_valid_file(parser, x, 'r'))
     parser.add_argument("-d", "--debug", action="store_true", help="Display verbose debug details")
     parser.add_argument("-p", "--poll", action="store_true", help="poll job status until job completes")
+    parser.add_argument("-k", "--apikey", default="apikey.txt", help="File containing the LAVA api key")
+    parser.add_argument("--port", default="80", help="LAVA/Apache default port number")
 
     return parser.parse_args()
 
@@ -88,12 +90,12 @@ def process():
     print "Submitting test job to LAVA server"
     loadConfiguration()
     user = "admin"
-    with open("/apikey.txt") as f: 
+    with open(args.apikey) as f:
         line = f.readline()
         apikey = line.rstrip('\n')
 
-    server_str = 'http://localhost'
-    xmlrpc_str = 'http://' + user + ":" + apikey + "@localhost" + '/RPC2/'
+    server_str = 'http://localhost' + ":" + args.port
+    xmlrpc_str = 'http://' + user + ":" + apikey + "@localhost" + ":" + args.port + '/RPC2/'
     server = xmlrpclib.ServerProxy(xmlrpc_str)
     server.system.listMethods()
 


### PR DESCRIPTION
This is so I can publish jobs from the host machine, and avoid using the container itself to send jobs.

Requires more testing with the everything-in-the-container scenario, but pushing jobs from the host side works as expected.

Proposing for review and comments.