### PR TITLE
Minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,6 @@ RUN /start.sh \
  # && cd /home/lava/lava-server && git checkout 30facc1290ad2dd28ed4ad41ff971546e360f92e \
  && cd /home/lava/lava-server \
  && git fetch https://review.linaro.org/lava/lava-server refs/changes/70/12670/1 && git cherry-pick FETCH_HEAD \
- && git fetch https://review.linaro.org/lava/lava-server refs/changes/23/12723/22 && git cherry-pick FETCH_HEAD \
  && echo "CORTEX-M3: add build then install capability to debian-dev-build.sh" \
  && echo "cd \${DIR} && dpkg -i *.deb" >> /home/lava/lava-server/share/debian-dev-build.sh \
  && echo "CORTEX-M3: Installing patched versions of dispatcher & server" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,12 +104,12 @@ RUN sudo apt-get update && apt-get install -y python-sphinx-bootstrap-theme node
 # CORTEX-M3: apply patches to enable cortex-m3 support
 RUN /start.sh \
  && echo "CORTEX-M3: adding patches for lava-dispatcher" \
- && git clone -b master https://github.com/linaro/lava-dispatcher /home/lava/lava-dispatcher \
+ && git clone -b master https://git.linaro.org/lava/lava-dispatcher.git /home/lava/lava-dispatcher \
  && cd /home/lava/lava-dispatcher \
  && git checkout 8753b43 \
  && git fetch https://review.linaro.org/lava/lava-dispatcher refs/changes/11/12711/9 && git cherry-pick FETCH_HEAD \
  && echo "CORTEX-M3: adding patches for lava-server" \
- && git clone -b master https://github.com/linaro/lava-server /home/lava/lava-server \
+ && git clone -b master https://git.linaro.org/lava/lava-server.git /home/lava/lava-server \
  # && cd /home/lava/lava-server && git checkout 30facc1290ad2dd28ed4ad41ff971546e360f92e \
  && cd /home/lava/lava-server \
  && git fetch https://review.linaro.org/lava/lava-server refs/changes/70/12670/1 && git cherry-pick FETCH_HEAD \


### PR DESCRIPTION
Patch #12723 has been merged upstream in the lava-server project, so remove it. Switch to using Linaro's git servers for source fetching.