### PR TITLE
start/stop: add lava-server-gunicorn handling

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -26,6 +26,7 @@ rm -f /var/run/lava-*.pid 2> /dev/null
 
 start postgresql
 start apache2
+start lava-server-gunicorn
 start lava-server
 start lava-master
 start lava-slave

--- a/stop.sh
+++ b/stop.sh
@@ -3,5 +3,6 @@
 service lava-master stop
 service lava-slave stop
 service lava-server stop
+service lava-server-gunicorn stop
 service apache2 stop
 service postgresql stop


### PR DESCRIPTION
lava-server-gunicorn should be started before lava-server.
Fix https://github.com/akbennett/lava-docker/issues/20

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>